### PR TITLE
Add npm token auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/repo
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
       - deploy:
           command: npm publish
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "freshsales",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
@hac-madkudu FYI, for open source repo, to avoid committing the .npmrc for publishing: 
https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/

(added NPM_TOKEN to env variables in CircleCI)